### PR TITLE
DroneCI config

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -1,0 +1,44 @@
+{
+  _config+:: {
+    jsonnet: 'quay.io/coreos/jsonnet-ci:latest',
+  },
+
+  kind: 'pipeline',
+  name: 'build',
+  platform: {
+    os: 'linux',
+    arch: 'amd64',
+  },
+
+  local jsonnet = {
+    name: 'jsonnet',
+    image: $._config.jsonnet,
+    pull: 'always',
+    environment: {
+      GO111MODULE: 'on',
+    },
+    when: {
+      event: {
+        exclude: ['tag'],
+      },
+    },
+  },
+
+  steps: [
+    jsonnet {
+      name: 'vendor',
+      commands: [
+        'make --always-make vendor',
+        'git diff --exit-code',
+      ],
+    },
+
+    jsonnet {
+      name: 'generate',
+      commands: [
+        'make --always-make generate',
+        'git diff --exit-code',
+      ],
+    },
+  ],
+}

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,36 @@
+---
+kind: pipeline
+name: build
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: vendor
+  pull: always
+  image: quay.io/coreos/jsonnet-ci:latest
+  commands:
+  - make --always-make vendor
+  - git diff --exit-code
+  environment:
+    GO111MODULE: on
+  when:
+    event:
+      exclude:
+      - tag
+
+- name: generate
+  pull: always
+  image: quay.io/coreos/jsonnet-ci:latest
+  commands:
+  - make --always-make generate
+  - git diff --exit-code
+  environment:
+    GO111MODULE: on
+  when:
+    event:
+      exclude:
+      - tag
+
+...

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
-JSONNET_FMT := jsonnet fmt -n 2 --max-blank-lines 2 --string-style s --comment-style s
+JSONNET_FMT := jsonnetfmt -n 2 --max-blank-lines 2 --string-style s --comment-style s
 
-JB_BINARY:=$(GOPATH)/bin/jb
-EMBEDMD_BINARY:=$(GOPATH)/bin/embedmd
 CONTAINER_CMD:=docker run --rm \
 		-u="$(shell id -u):$(shell id -g)" \
 		-v "$(shell go env GOCACHE):/.cache/go-build" \
 		-v "$(PWD):/go/src/github.com/metalmatze/kube-thanos:Z" \
 		-w "/go/src/github.com/metalmatze/kube-thanos" \
+		-e USER=deadbeef \
+		-e GO111MODULE=on \
 		quay.io/coreos/jsonnet-ci
 
-all: generate fmt test
+all: generate fmt
 
 .PHONY: generate-in-docker
 generate-in-docker:
@@ -18,25 +18,19 @@ generate-in-docker:
 
 generate: manifests **.md
 
-**.md: $(EMBEDMD_BINARY) $(shell find examples) build.sh example.jsonnet
-	$(EMBEDMD_BINARY) -w `find . -name "*.md" | grep -v vendor`
+**.md: $(shell find examples) build.sh example.jsonnet
+	embedmd -w `find . -name "*.md" | grep -v vendor`
 
 manifests: vendor example.jsonnet build.sh
 	rm -rf manifests
 	./build.sh
 
-vendor: $(JB_BINARY) jsonnetfile.json jsonnetfile.lock.json
+vendor: jsonnetfile.json jsonnetfile.lock.json
 	rm -rf vendor
-	$(JB_BINARY) install
+	jb install
 
 fmt:
 	find . -name 'vendor' -prune -o -name '*.libsonnet' -o -name '*.jsonnet' -print | \
 		xargs -n 1 -- $(JSONNET_FMT) -i
-
-$(JB_BINARY):
-	go get -u github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
-
-$(EMBEDMD_BINARY):
-	go get github.com/campoy/embedmd
 
 .PHONY: generate generate-in-docker fmt


### PR DESCRIPTION
Cleaning up Makefile:
 - use jsonnet 0.13 and use `jsonnetfmt` instead of `jsonnet fmt`
 - remove reference to non-existing `test` target
 - remove installation of build tools as they are already provided in a container image
 - enable go modules (for future :) )

Creating drone CI config based on https://github.com/jsonnet-bundler/jsonnet-bundler/blob/master/.drone.yml and https://github.com/coreos/kube-prometheus/blob/master/.travis.yml. CI should use our `quay.io/coreos/jsonnet-ci` image as this is shipping with all necessary tools.