### PR TITLE
Don't use global _config object

### DIFF
--- a/example.jsonnet
+++ b/example.jsonnet
@@ -9,9 +9,11 @@ local kt =
   // (import 'kube-thanos/kube-thanos-receive.libsonnet') +
   {
     thanos+:: {
-      variables+: {
-        images+: {
-          thanos: 'improbable/thanos:v0.5.0',
+      variables+:: {
+        image: 'improbable/thanos:v0.5.0',
+        objectStorageConfig+: {
+          name: 'thanos-objectstorage',
+          key: 'thanos.yaml',
         },
       },
 

--- a/example.jsonnet
+++ b/example.jsonnet
@@ -8,23 +8,13 @@ local kt =
   // (import 'kube-thanos/kube-thanos-pvc.libsonnet') + // Uncomment this line to enable PVCs
   // (import 'kube-thanos/kube-thanos-receive.libsonnet') +
   {
-    _config+:: {
-      namespace: 'monitoring',
-
-      images+: {
-        thanos: 'improbable/thanos:v0.5.0',
-      },
-
-      thanos+: {
-        // MAKE SURE TO CREATE THE SECRET FIRST
-        objectStorageConfig+: {
-          name: 'thanos-objectstorage',
-          key: 'thanos.yaml',
+    thanos+:: {
+      variables+: {
+        images+: {
+          thanos: 'improbable/thanos:v0.5.0',
         },
       },
-    },
 
-    thanos+:: {
       querier+: {
         deployment+:
           deployment.mixin.spec.withReplicas(3),

--- a/jsonnet/kube-thanos/kube-thanos-pvc.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-pvc.libsonnet
@@ -1,17 +1,15 @@
 local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
 
 {
-  _config+:: {
-    store+: {
-      pvc+: {
-        class: 'standard',
-        size: '10Gi',
-      },
-    },
-  },
-
   thanos+:: {
     store+: {
+      variables+:: {
+        pvc+: {
+          class: 'standard',
+          size: '10Gi',
+        },
+      },
+
       statefulSet+:
         local sts = k.apps.v1.statefulSet;
         local pvc = sts.mixin.spec.volumeClaimTemplatesType;
@@ -32,10 +30,10 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
                   accessModes: [
                     'ReadWriteOnce',
                   ],
-                  storageClassName: $._config.store.pvc.class,
+                  storageClassName: $.thanos.store.variables.pvc.class,
                   resources: {
                     requests: {
-                      storage: $._config.store.pvc.size,
+                      storage: $.thanos.store.variables.pvc.size,
                     },
                   },
                 },

--- a/jsonnet/kube-thanos/kube-thanos-querier.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-querier.libsonnet
@@ -3,51 +3,33 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
 {
   thanos+:: {
     querier+: {
-      variables+: {
-        name: 'thanos-querier',
-        namespace: 'monitoring',
-        labels: { app: $.thanos.querier.variables.name },
-        images: {
-          thanos: $.thanos.variables.images.thanos,
-        },
-      },
-
       service:
         local service = k.core.v1.service;
         local ports = service.mixin.spec.portsType;
 
         service.new(
-          $.thanos.querier.variables.name,
-          $.thanos.querier.variables.labels,
+          'thanos-querier',
+          $.thanos.querier.deployment.metadata.labels,
           [
             ports.newNamed('grpc', 10901, 10901),
             ports.newNamed('http', 9090, 10902),
           ]
         ) +
-        service.mixin.metadata.withNamespace($.thanos.querier.variables.namespace) +
-        service.mixin.metadata.withLabels($.thanos.querier.variables.labels),
+        service.mixin.metadata.withNamespace('monitoring') +
+        service.mixin.metadata.withLabels({ app: $.thanos.querier.service.metadata.name }),
 
       deployment:
         local deployment = k.apps.v1.deployment;
         local container = deployment.mixin.spec.template.spec.containersType;
 
-        local args = [
-          'query',
-          '--query.replica-label=replica',
-          // '--store=dnssrv+%s.%s.svc.cluster.local:%d' % [
-          //   $.thanos.store.service.metadata.name,
-          //   $.thanos.store.service.metadata.namespace,
-          //   12314,
-          // ],
-        ];
-
         local c =
-          container.new($.thanos.querier.variables.name, $.thanos.querier.variables.images.thanos) +
-          container.withArgs(args);
+          container.new($.thanos.querier.deployment.metadata.name, $.thanos.variables.image) +
+          container.withArgs(['query', '--query.replica-label=replica']);
 
-        deployment.new($.thanos.querier.variables.name, 1, c, $.thanos.querier.variables.labels) +
-        deployment.mixin.metadata.withNamespace($.thanos.querier.variables.namespace) +
-        deployment.mixin.spec.selector.withMatchLabels($.thanos.querier.variables.labels),
+        deployment.new('thanos-querier', 1, c, $.thanos.querier.deployment.metadata.labels) +
+        deployment.mixin.metadata.withNamespace('monitoring') +
+        deployment.mixin.metadata.withLabels({ app: $.thanos.querier.deployment.metadata.name }) +
+        deployment.mixin.spec.selector.withMatchLabels($.thanos.querier.deployment.metadata.labels),
     },
   },
 }

--- a/jsonnet/kube-thanos/kube-thanos-querier.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-querier.libsonnet
@@ -1,33 +1,31 @@
 local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
 
 {
-  _config+:: {
-    querier+: {
-      name: 'thanos-querier',
-      labels: { app: $._config.querier.name },
-      ports: {
-        grpc: 10901,
-        http: 10902,
-      },
-    },
-  },
-
   thanos+:: {
     querier+: {
+      variables+: {
+        name: 'thanos-querier',
+        namespace: 'monitoring',
+        labels: { app: $.thanos.querier.variables.name },
+        images: {
+          thanos: $.thanos.variables.images.thanos,
+        },
+      },
+
       service:
         local service = k.core.v1.service;
         local ports = service.mixin.spec.portsType;
 
         service.new(
-          $._config.querier.name,
-          $._config.querier.labels,
+          $.thanos.querier.variables.name,
+          $.thanos.querier.variables.labels,
           [
-            ports.newNamed('grpc', $._config.querier.ports.grpc, $._config.querier.ports.grpc),
-            ports.newNamed('http', 9090, $._config.querier.ports.http),
+            ports.newNamed('grpc', 10901, 10901),
+            ports.newNamed('http', 9090, 10902),
           ]
         ) +
-        service.mixin.metadata.withNamespace($._config.namespace) +
-        service.mixin.metadata.withLabels($._config.querier.labels),
+        service.mixin.metadata.withNamespace($.thanos.querier.variables.namespace) +
+        service.mixin.metadata.withLabels($.thanos.querier.variables.labels),
 
       deployment:
         local deployment = k.apps.v1.deployment;
@@ -36,20 +34,20 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         local args = [
           'query',
           '--query.replica-label=replica',
-          '--store=dnssrv+%s.%s.svc.cluster.local:%d' % [
-            $.thanos.store.service.metadata.name,
-            $._config.namespace,
-            $._config.store.ports.grpc,
-          ],
+          // '--store=dnssrv+%s.%s.svc.cluster.local:%d' % [
+          //   $.thanos.store.service.metadata.name,
+          //   $.thanos.store.service.metadata.namespace,
+          //   12314,
+          // ],
         ];
 
         local c =
-          container.new($._config.querier.name, $._config.images.thanos) +
+          container.new($.thanos.querier.variables.name, $.thanos.querier.variables.images.thanos) +
           container.withArgs(args);
 
-        deployment.new($._config.querier.name, 1, c, $._config.querier.labels) +
-        deployment.mixin.metadata.withNamespace($._config.namespace) +
-        deployment.mixin.spec.selector.withMatchLabels($._config.querier.labels),
+        deployment.new($.thanos.querier.variables.name, 1, c, $.thanos.querier.variables.labels) +
+        deployment.mixin.metadata.withNamespace($.thanos.querier.variables.namespace) +
+        deployment.mixin.spec.selector.withMatchLabels($.thanos.querier.variables.labels),
     },
   },
 }

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -74,8 +74,8 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
                 { args+: [
                   '--store=dnssrv+%s.%s.svc.cluster.local:%d' % [
                     $.thanos.receive.service.metadata.name,
-                    $._config.namespace,
-                    $._config.receive.ports.grpc,
+                    $.thanos.receive.service.metadata.namespace,
+                    $.thanos.receive.service.spec.ports[0].port,
                   ],
                 ] },
               ],

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -1,17 +1,6 @@
 local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
 
 {
-  _config+:: {
-    receive+: {
-      name: 'thanos-receive',
-      labels: { app: $._config.receive.name },
-      ports: {
-        grpc: 10901,
-        remoteWrite: 19291,
-      },
-    },
-  },
-
   thanos+:: {
     receive: {
       service:
@@ -19,15 +8,15 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         local ports = service.mixin.spec.portsType;
 
         service.new(
-          $._config.receive.name,
-          $._config.receive.labels,
+          'thanos-receive',
+          $.thanos.receive.statefulSet.metadata.labels,
           [
-            ports.newNamed('grpc', $._config.receive.ports.grpc, $._config.receive.ports.grpc),
-            ports.newNamed('remote-write', $._config.receive.ports.remoteWrite, $._config.receive.ports.remoteWrite),
+            ports.newNamed('grpc', 10901, 10901),
+            ports.newNamed('remote-write', 19291, 19291),
           ]
         ) +
-        service.mixin.metadata.withNamespace($._config.namespace) +
-        service.mixin.metadata.withLabels($._config.receive.labels) +
+        service.mixin.metadata.withNamespace('monitoring') +
+        service.mixin.metadata.withLabels({ app: $.thanos.receive.service.metadata.name }) +
         service.mixin.spec.withClusterIp('None'),
 
       statefulSet:
@@ -38,30 +27,30 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         local containerVolumeMount = container.volumeMountsType;
 
         local c =
-          container.new($._config.store.name, $._config.images.thanos) +
+          container.new($.thanos.receive.statefulSet.metadata.name, $.thanos.variables.image) +
           container.withArgs([
             'receive',
-            '--remote-write.address=0.0.0.0:%d' % $._config.receive.ports.remoteWrite,
-            '--grpc-address=0.0.0.0:%d' % $._config.receive.ports.grpc,
+            '--grpc-address=0.0.0.0:%d' % $.thanos.receive.service.spec.ports[0].port,
+            '--remote-write.address=0.0.0.0:%d' % $.thanos.receive.service.spec.ports[1].port,
             '--objstore.config=$(OBJSTORE_CONFIG)',
           ]) +
           container.withEnv([
             containerEnv.fromSecretRef(
               'OBJSTORE_CONFIG',
-              $._config.thanos.objectStorageConfig.name,
-              $._config.thanos.objectStorageConfig.key,
+              $.thanos.variables.objectStorageConfig.name,
+              $.thanos.variables.objectStorageConfig.key,
             ),
           ]) +
           container.withPorts([
-            { name: 'grpc', containerPort: $._config.receive.ports.grpc },
-            { name: 'remote-write', containerPort: $._config.receive.ports.remoteWrite },
+            { name: 'grpc', containerPort: $.thanos.receive.service.spec.ports[0].port },
+            { name: 'remote-write', containerPort: $.thanos.receive.service.spec.ports[1].port },
           ]);
 
-        sts.new($._config.receive.name, 3, c, [], $._config.receive.labels) +
-        sts.mixin.metadata.withNamespace($._config.namespace) +
-        sts.mixin.metadata.withLabels($._config.receive.labels) +
+        sts.new('thanos-receive', 3, c, [], $.thanos.receive.statefulSet.metadata.labels) +
+        sts.mixin.metadata.withNamespace('monitoring') +
+        sts.mixin.metadata.withLabels({ app: $.thanos.receive.statefulSet.metadata.name }) +
         sts.mixin.spec.withServiceName($.thanos.receive.service.metadata.name) +
-        sts.mixin.spec.selector.withMatchLabels($._config.receive.labels),
+        sts.mixin.spec.selector.withMatchLabels($.thanos.receive.statefulSet.metadata.labels),
     },
 
     querier+: {
@@ -70,7 +59,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           template+: {
             spec+: {
               containers: [
-                super.containers[0] +
+                super.containers[0]
                 { args+: [
                   '--store=dnssrv+%s.%s.svc.cluster.local:%d' % [
                     $.thanos.receive.service.metadata.name,

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/kube-thanos"
                 }
             },
-            "version": "961fd9573cd9651f5f393f2839716dc624cb00be"
+            "version": "d75b1d9959aa253d66336e041cfc6ee652382446"
         },
         {
             "name": "ksonnet",

--- a/manifests/thanos-querier-deployment.yaml
+++ b/manifests/thanos-querier-deployment.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    app: thanos-querier
   name: thanos-querier
   namespace: monitoring
 spec:

--- a/manifests/thanos-store-statefulSet.yaml
+++ b/manifests/thanos-store-statefulSet.yaml
@@ -33,8 +33,6 @@ spec:
         ports:
         - containerPort: 10901
           name: grpc
-        - containerPort: 10902
-          name: http
         volumeMounts:
         - mountPath: /var/thanos/store
           name: data


### PR DESCRIPTION
In a few recent discussions with @ant31 it became very obvious, that using the `_config` was a mistake I and others ran into writing Kubernetes manifests.

This is a first PR trying to clean up a lot of things.
Only the `$.thanos.variables.image` and `$.thanos.variables.objectStorageConfig` are still some what global (but scoped to the Thanos object) as mutliple components need to reference those.

/cc @squat @brancz @aditya-konarde