### PR TITLE
Generate all components to examples/all

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ local kt =
 { ['thanos-querier-' + name]: kt.thanos.querier[name] for name in std.objectFields(kt.thanos.querier) } +
 { ['thanos-store-' + name]: kt.thanos.store[name] for name in std.objectFields(kt.thanos.store) }
 // { ['thanos-receive-' + name]: kt.thanos.receive[name] for name in std.objectFields(kt.thanos.receive) }
+
+
+
 ```
 
 And here's the [build.sh](build.sh) script (which uses `vendor/` to render all manifests in a json structure of `{filename: manifest-content}`):
@@ -122,9 +125,15 @@ set -o pipefail
 rm -rf manifests
 mkdir manifests
 
-                                               # optional, but we would like to generate yaml, not json
+# optional, but we would like to generate yaml, not json
 jsonnet -J vendor -m manifests "${1-example.jsonnet}" | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml; rm -f {}' -- {}
 
+# The following script generates all components, mostly used for testing
+
+rm -rf examples/all/manifests
+mkdir examples/all/manifests
+
+jsonnet -J vendor -m examples/all/manifests "${1-all.jsonnet}" | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml; rm -f {}' -- {}
 ```
 
 > Note you need `jsonnet` (`go get github.com/google/go-jsonnet/cmd/jsonnet`) and `gojsontoyaml` (`go get github.com/brancz/gojsontoyaml`) installed to run `build.sh`. If you just want json output, not yaml, then you can skip the pipe and everything afterwards.

--- a/all.jsonnet
+++ b/all.jsonnet
@@ -1,0 +1,35 @@
+local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
+local sts = k.apps.v1.statefulSet;
+local deployment = k.apps.v1.deployment;
+
+local kt =
+  (import 'kube-thanos/kube-thanos-querier.libsonnet') +
+  (import 'kube-thanos/kube-thanos-store.libsonnet') +
+  (import 'kube-thanos/kube-thanos-pvc.libsonnet') +
+  (import 'kube-thanos/kube-thanos-receive.libsonnet') +
+  (import 'kube-thanos/kube-thanos-sidecar.libsonnet') +
+  (import 'kube-thanos/kube-thanos-servicemonitors.libsonnet') +
+  {
+    thanos+:: {
+      variables+:: {
+        image: 'improbable/thanos:v0.5.0',
+        objectStorageConfig+: {
+          name: 'thanos-objectstorage',
+          key: 'thanos.yaml',
+        },
+      },
+
+      querier+: {
+        deployment+:
+          deployment.mixin.spec.withReplicas(3),
+      },
+      store+: {
+        statefulSet+:
+          sts.mixin.spec.withReplicas(5),
+      },
+    },
+  };
+
+{ ['thanos-querier-' + name]: kt.thanos.querier[name] for name in std.objectFields(kt.thanos.querier) } +
+{ ['thanos-store-' + name]: kt.thanos.store[name] for name in std.objectFields(kt.thanos.store) }
+{ ['thanos-receive-' + name]: kt.thanos.receive[name] for name in std.objectFields(kt.thanos.receive) }

--- a/build.sh
+++ b/build.sh
@@ -11,6 +11,12 @@ set -o pipefail
 rm -rf manifests
 mkdir manifests
 
-                                               # optional, but we would like to generate yaml, not json
+# optional, but we would like to generate yaml, not json
 jsonnet -J vendor -m manifests "${1-example.jsonnet}" | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml; rm -f {}' -- {}
 
+# The following script generates all components, mostly used for testing
+
+rm -rf examples/all/manifests
+mkdir examples/all/manifests
+
+jsonnet -J vendor -m examples/all/manifests "${1-all.jsonnet}" | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml; rm -f {}' -- {}

--- a/example.jsonnet
+++ b/example.jsonnet
@@ -33,3 +33,6 @@ local kt =
 { ['thanos-querier-' + name]: kt.thanos.querier[name] for name in std.objectFields(kt.thanos.querier) } +
 { ['thanos-store-' + name]: kt.thanos.store[name] for name in std.objectFields(kt.thanos.store) }
 // { ['thanos-receive-' + name]: kt.thanos.receive[name] for name in std.objectFields(kt.thanos.receive) }
+
+
+

--- a/examples/all/manifests/thanos-querier-deployment.yaml
+++ b/examples/all/manifests/thanos-querier-deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: thanos-querier
+  name: thanos-querier
+  namespace: monitoring
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: thanos-querier
+  template:
+    metadata:
+      labels:
+        app: thanos-querier
+    spec:
+      containers:
+      - args:
+        - query
+        - --query.replica-label=replica
+        - --store=dnssrv+_grpc._tcp.thanos-store.monitoring.svc.cluster.local
+        - --store=dnssrv+_grpc._tcp.thanos-receive.monitoring.svc.cluster.local
+        - --store=dnssrv+_grpc._tcp.prometheus-k8s.monitoring.svc.cluster.local
+        image: improbable/thanos:v0.5.0
+        name: thanos-querier

--- a/examples/all/manifests/thanos-querier-service.yaml
+++ b/examples/all/manifests/thanos-querier-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: thanos-querier
+  name: thanos-querier
+  namespace: monitoring
+spec:
+  ports:
+  - name: grpc
+    port: 10901
+    targetPort: 10901
+  - name: http
+    port: 9090
+    targetPort: 10902
+  selector:
+    app: thanos-querier

--- a/examples/all/manifests/thanos-querier-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-querier-serviceMonitor.yaml
@@ -1,0 +1,11 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: thanos-querier
+  namespace: monitoring
+spec:
+  endpoints:
+  - port: http
+  selector:
+    matchLabels:
+      app: thanos-querier

--- a/examples/all/manifests/thanos-receive-service.yaml
+++ b/examples/all/manifests/thanos-receive-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: thanos-receive
+  name: thanos-receive
+  namespace: monitoring
+spec:
+  clusterIP: None
+  ports:
+  - name: grpc
+    port: 10901
+    targetPort: 10901
+  - name: http
+    port: 10902
+    targetPort: 10902
+  - name: remote-write
+    port: 19291
+    targetPort: 19291
+  selector:
+    app: thanos-receive

--- a/examples/all/manifests/thanos-receive-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-receive-serviceMonitor.yaml
@@ -1,0 +1,11 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: thanos-receive
+  namespace: monitoring
+spec:
+  endpoints:
+  - port: http
+  selector:
+    matchLabels:
+      app: thanos-receive

--- a/examples/all/manifests/thanos-receive-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-statefulSet.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app: thanos-receive
+  name: thanos-receive
+  namespace: monitoring
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: thanos-receive
+  serviceName: thanos-receive
+  template:
+    metadata:
+      labels:
+        app: thanos-receive
+    spec:
+      containers:
+      - args:
+        - receive
+        - --grpc-address=0.0.0.0:10901
+        - --remote-write.address=0.0.0.0:10902
+        - --objstore.config=$(OBJSTORE_CONFIG)
+        - --tsdb.path=/var/thanos/tsdb
+        env:
+        - name: OBJSTORE_CONFIG
+          valueFrom:
+            secretKeyRef:
+              key: thanos.yaml
+              name: thanos-objectstorage
+        image: improbable/thanos:v0.5.0
+        name: thanos-receive
+        ports:
+        - containerPort: 10901
+          name: grpc
+        - containerPort: 10902
+          name: remote-write
+        volumeMounts:
+        - mountPath: /var/thanos/tsdb
+          name: data
+          readOnly: false
+      volumes:
+      - emptyDir: {}
+        name: data
+  volumeClaimTemplates: []

--- a/examples/all/manifests/thanos-store-service.yaml
+++ b/examples/all/manifests/thanos-store-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: thanos-store
+  name: thanos-store
+  namespace: monitoring
+spec:
+  clusterIP: None
+  ports:
+  - name: grpc
+    port: 10901
+    targetPort: 10901
+  - name: http
+    port: 10902
+    targetPort: 10902
+  selector:
+    app: thanos-store

--- a/examples/all/manifests/thanos-store-serviceMonitor.yaml
+++ b/examples/all/manifests/thanos-store-serviceMonitor.yaml
@@ -1,0 +1,11 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: thanos-store
+  namespace: monitoring
+spec:
+  endpoints:
+  - port: http
+  selector:
+    matchLabels:
+      app: thanos-store

--- a/examples/all/manifests/thanos-store-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app: thanos-store
+  name: thanos-store
+  namespace: monitoring
+spec:
+  replicas: 5
+  selector:
+    matchLabels:
+      app: thanos-store
+  serviceName: thanos-store
+  template:
+    metadata:
+      labels:
+        app: thanos-store
+    spec:
+      containers:
+      - args:
+        - store
+        - --data-dir=/var/thanos/store
+        - --grpc-address=0.0.0.0:10901
+        - --objstore.config=$(OBJSTORE_CONFIG)
+        env:
+        - name: OBJSTORE_CONFIG
+          valueFrom:
+            secretKeyRef:
+              key: thanos.yaml
+              name: thanos-objectstorage
+        image: improbable/thanos:v0.5.0
+        name: thanos-store
+        ports:
+        - containerPort: 10901
+          name: grpc
+        volumeMounts:
+        - mountPath: /var/thanos/store
+          name: data
+          readOnly: false
+      volumes: []
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi
+      storageClassName: standard


### PR DESCRIPTION
This example is mostly for quality assurance of all components together.
Having this in place will more likely catch a mistake of changing something that's not included in the default example.jsonnet

/cc @brancz @kakkoyun @paulfantom 