### PR TITLE
Add external label to the receive component

### DIFF
--- a/examples/all/manifests/thanos-receive-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-statefulSet.yaml
@@ -23,7 +23,8 @@ spec:
         - --remote-write.address=0.0.0.0:19291
         - --objstore.config=$(OBJSTORE_CONFIG)
         - --tsdb.path=/var/thanos/tsdb
-        - --labels=receive=$(NAME)
+        - --labels=replica=$(NAME)
+        - --labels=receive="true"
         env:
         - name: NAME
           valueFrom:

--- a/examples/all/manifests/thanos-receive-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-statefulSet.yaml
@@ -20,10 +20,15 @@ spec:
       - args:
         - receive
         - --grpc-address=0.0.0.0:10901
-        - --remote-write.address=0.0.0.0:10902
+        - --remote-write.address=0.0.0.0:19291
         - --objstore.config=$(OBJSTORE_CONFIG)
         - --tsdb.path=/var/thanos/tsdb
+        - --labels=receive=$(NAME)
         env:
+        - name: NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: OBJSTORE_CONFIG
           valueFrom:
             secretKeyRef:
@@ -35,6 +40,8 @@ spec:
         - containerPort: 10901
           name: grpc
         - containerPort: 10902
+          name: http
+        - containerPort: 19291
           name: remote-write
         volumeMounts:
         - mountPath: /var/thanos/tsdb

--- a/examples/all/manifests/thanos-receive-statefulSet.yaml
+++ b/examples/all/manifests/thanos-receive-statefulSet.yaml
@@ -23,7 +23,7 @@ spec:
         - --remote-write.address=0.0.0.0:19291
         - --objstore.config=$(OBJSTORE_CONFIG)
         - --tsdb.path=/var/thanos/tsdb
-        - --labels=replica=$(NAME)
+        - --labels=replica="$(NAME)"
         - --labels=receive="true"
         env:
         - name: NAME

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -35,7 +35,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
             '--remote-write.address=0.0.0.0:%d' % $.thanos.receive.service.spec.ports[2].port,
             '--objstore.config=$(OBJSTORE_CONFIG)',
             '--tsdb.path=/var/thanos/tsdb',
-            '--labels=replica=$(NAME)',
+            '--labels=replica="$(NAME)"',
             '--labels=receive="true"',
           ]) +
           container.withEnv([

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -35,8 +35,10 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
             '--remote-write.address=0.0.0.0:%d' % $.thanos.receive.service.spec.ports[2].port,
             '--objstore.config=$(OBJSTORE_CONFIG)',
             '--tsdb.path=/var/thanos/tsdb',
+            '--labels=receive=$(NAME)',
           ]) +
           container.withEnv([
+            containerEnv.fromFieldPath('NAME', 'metadata.name'),
             containerEnv.fromSecretRef(
               'OBJSTORE_CONFIG',
               $.thanos.variables.objectStorageConfig.name,

--- a/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-receive.libsonnet
@@ -35,7 +35,8 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
             '--remote-write.address=0.0.0.0:%d' % $.thanos.receive.service.spec.ports[2].port,
             '--objstore.config=$(OBJSTORE_CONFIG)',
             '--tsdb.path=/var/thanos/tsdb',
-            '--labels=receive=$(NAME)',
+            '--labels=replica=$(NAME)',
+            '--labels=receive="true"',
           ]) +
           container.withEnv([
             containerEnv.fromFieldPath('NAME', 'metadata.name'),

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/kube-thanos"
                 }
             },
-            "version": "851ed4d4cbd0cd67c8c0c3ab44996d22839a16d9"
+            "version": "b4a742d49decf4b34b22033a21d4b0e084789941"
         },
         {
             "name": "ksonnet",

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/kube-thanos"
                 }
             },
-            "version": "48e5fbda534c55183f7075bb8e190d1f00cf3387"
+            "version": "851ed4d4cbd0cd67c8c0c3ab44996d22839a16d9"
         },
         {
             "name": "ksonnet",

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/kube-thanos"
                 }
             },
-            "version": "b4a742d49decf4b34b22033a21d4b0e084789941"
+            "version": "40707dbbbd114d85dceb8dba67eb92195bcc5dda"
         },
         {
             "name": "ksonnet",


### PR DESCRIPTION
Adding this label should fix the issue we currently see:
```
level=warn ts=2019-07-15T11:30:15.59135313Z caller=receive.go:284 component=receive err="failed to sync 3 blocks" uploaded=0
level=info ts=2019-07-15T11:30:45.582197204Z caller=shipper.go:350 component=receive msg="upload new block" id=01DFT3NPXG9ZHMDJ5EES257QBB
level=error ts=2019-07-15T11:30:45.584394983Z caller=shipper.go:317 component=receive msg="shipping failed" block=01DFT3NPXG9ZHMDJ5EES257QBB err="empty external labels are not allowed for Thanos block."
```