### PR TITLE
Fix alerts and relax thresholds for latency alerts

### DIFF
--- a/jsonnet/thanos-mixin/alerts.yaml
+++ b/jsonnet/thanos-mixin/alerts.yaml
@@ -55,8 +55,8 @@ groups:
         for HTTP requests.
     expr: |
       histogram_quantile(0.99,
-        sum(thanos_http_request_duration_seconds{job="thanos-receive"}) by (le)
-      ) > 1
+        sum(thanos_http_request_duration_seconds_bucket{job="thanos-receive"}) by (le)
+      ) > 10
     for: 10m
     labels:
       severity: warning
@@ -104,7 +104,7 @@ groups:
         for store series gate requests.
     expr: |
       histogram_quantile(0.99,
-        sum(thanos_bucket_store_series_gate_duration_seconds{job="thanos-store"}) by (le)
+        sum(thanos_bucket_store_series_gate_duration_seconds_bucket{job="thanos-store"}) by (le)
       ) > 2
     for: 10m
     labels:
@@ -127,7 +127,7 @@ groups:
         for bucket operations.
     expr: |
       histogram_quantile(0.99,
-        sum(thanos_objstore_bucket_operation_duration_seconds{job="thanos-querier"}) by (le)
+        sum(thanos_objstore_bucket_operation_duration_seconds_bucket{job="thanos-store"}) by (le)
       ) > 15
     for: 10m
     labels:

--- a/jsonnet/thanos-mixin/alerts.yaml
+++ b/jsonnet/thanos-mixin/alerts.yaml
@@ -32,7 +32,7 @@ groups:
     expr: |
       histogram_quantile(0.99,
         sum(thanos_query_api_instant_query_duration_seconds_bucket{job="thanos-querier"}) by (le)
-      ) > 1
+      ) > 10
     for: 10m
     labels:
       severity: warning
@@ -43,7 +43,7 @@ groups:
     expr: |
       histogram_quantile(0.99,
         sum(thanos_query_api_range_query_duration_seconds_bucket{job="thanos-querier"}) by (le)
-      ) > 1
+      ) > 10
     for: 10m
     labels:
       severity: warning

--- a/jsonnet/thanos-mixin/alerts/querier.libsonnet
+++ b/jsonnet/thanos-mixin/alerts/querier.libsonnet
@@ -46,7 +46,7 @@
             expr: |||
               histogram_quantile(0.99,
                 sum(thanos_query_api_instant_query_duration_seconds_bucket{%(thanosQuerierSelector)s}) by (le)
-              ) > 1
+              ) > 10
             ||| % $._config,
             'for': '10m',
             labels: {
@@ -61,7 +61,7 @@
             expr: |||
               histogram_quantile(0.99,
                 sum(thanos_query_api_range_query_duration_seconds_bucket{%(thanosQuerierSelector)s}) by (le)
-              ) > 1
+              ) > 10
             ||| % $._config,
             'for': '10m',
             labels: {

--- a/jsonnet/thanos-mixin/alerts/receive.libsonnet
+++ b/jsonnet/thanos-mixin/alerts/receive.libsonnet
@@ -11,8 +11,8 @@
             },
             expr: |||
               histogram_quantile(0.99,
-                sum(thanos_http_request_duration_seconds{%(thanosReceiveSelector)s}) by (le)
-              ) > 1
+                sum(thanos_http_request_duration_seconds_bucket{%(thanosReceiveSelector)s}) by (le)
+              ) > 10
             ||| % $._config,
             'for': '10m',
             labels: {

--- a/jsonnet/thanos-mixin/alerts/store.libsonnet
+++ b/jsonnet/thanos-mixin/alerts/store.libsonnet
@@ -28,7 +28,7 @@
             },
             expr: |||
               histogram_quantile(0.99,
-                sum(thanos_bucket_store_series_gate_duration_seconds{%(thanosStoreSelector)s}) by (le)
+                sum(thanos_bucket_store_series_gate_duration_seconds_bucket{%(thanosStoreSelector)s}) by (le)
               ) > 2
             ||| % $._config,
             'for': '10m',
@@ -60,7 +60,7 @@
             },
             expr: |||
               histogram_quantile(0.99,
-                sum(thanos_objstore_bucket_operation_duration_seconds{%(thanosQuerierSelector)s}) by (le)
+                sum(thanos_objstore_bucket_operation_duration_seconds_bucket{%(thanosStoreSelector)s}) by (le)
               ) > 15
             ||| % $._config,
             'for': '10m',


### PR DESCRIPTION
A few alerts had broken metric names that I fixed. The latency alerts with 1s might be too triggery, relax them for now until we have some data to investigate with.