### PR TITLE
Thanos querier: fix querier ports

### DIFF
--- a/examples/all/manifests/thanos-querier-service.yaml
+++ b/examples/all/manifests/thanos-querier-service.yaml
@@ -9,9 +9,9 @@ spec:
   ports:
   - name: grpc
     port: 10901
-    targetPort: 10901
+    targetPort: grpc
   - name: http
     port: 9090
-    targetPort: 10902
+    targetPort: http
   selector:
     app: thanos-querier

--- a/jsonnet/kube-thanos/kube-thanos-querier.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-querier.libsonnet
@@ -11,8 +11,8 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           'thanos-querier',
           $.thanos.querier.deployment.metadata.labels,
           [
-            ports.newNamed('grpc', 10901, 10901),
-            ports.newNamed('http', 9090, 10902),
+            ports.newNamed('grpc', 10901, 'grpc'),
+            ports.newNamed('http', 9090, 'http'),
           ]
         ) +
         service.mixin.metadata.withNamespace('monitoring') +

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -8,7 +8,7 @@
                     "subdir": "jsonnet/kube-thanos"
                 }
             },
-            "version": "a973b06ed653fe1eab713e4ff854919689d72543"
+            "version": "6038a324a9f031da070b9891f5413e291e2b353d"
         },
         {
             "name": "ksonnet",

--- a/manifests/thanos-querier-service.yaml
+++ b/manifests/thanos-querier-service.yaml
@@ -9,9 +9,9 @@ spec:
   ports:
   - name: grpc
     port: 10901
-    targetPort: 10901
+    targetPort: grpc
   - name: http
     port: 9090
-    targetPort: 10902
+    targetPort: http
   selector:
     app: thanos-querier


### PR DESCRIPTION
Currently, the thanos querier service points to canonical ports 10901, and 10902. While 10901 is correct, 10902 is not (it should be 9090).

This fixes it by referencing the named ports `grpc` and `http` in the thanos querier service.

/cc @metalmatze @lilic @paulfantom @squat 