### PR TITLE
Rename Thanos Store PVC and bump size to 50Gi

### DIFF
--- a/examples/all/manifests/thanos-store-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet.yaml
@@ -45,12 +45,12 @@ spec:
             memory: 1Gi
         volumeMounts:
         - mountPath: /var/thanos/store
-          name: data
+          name: thanos-store-data
           readOnly: false
       volumes: []
   volumeClaimTemplates:
   - metadata:
-      name: data
+      name: thanos-store-data
     spec:
       accessModes:
       - ReadWriteOnce

--- a/examples/all/manifests/thanos-store-statefulSet.yaml
+++ b/examples/all/manifests/thanos-store-statefulSet.yaml
@@ -56,5 +56,5 @@ spec:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 10Gi
+          storage: 50Gi
       storageClassName: standard

--- a/jsonnet/kube-thanos/kube-thanos-pvc.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-pvc.libsonnet
@@ -24,7 +24,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
             volumeClaimTemplates::: [
               {
                 metadata: {
-                  name: 'data',
+                  name: $.thanos.store.statefulSet.metadata.name + '-data',
                 },
                 spec: {
                   accessModes: [

--- a/jsonnet/kube-thanos/kube-thanos-pvc.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-pvc.libsonnet
@@ -6,7 +6,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       variables+:: {
         pvc+: {
           class: 'standard',
-          size: '10Gi',
+          size: '50Gi',
         },
       },
 

--- a/jsonnet/kube-thanos/kube-thanos-store.libsonnet
+++ b/jsonnet/kube-thanos/kube-thanos-store.libsonnet
@@ -56,7 +56,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           container.mixin.resources.withRequests({ cpu: '500m', memory: '1Gi' }) +
           container.mixin.resources.withLimits({ cpu: '2', memory: '8Gi' }) +
           container.withVolumeMounts([
-            containerVolumeMount.new('data', '/var/thanos/store', false),
+            containerVolumeMount.new($.thanos.store.statefulSet.metadata.name + '-data', '/var/thanos/store', false),
           ]);
 
         sts.new('thanos-store', 3, c, [], $.thanos.store.statefulSet.metadata.labels) +
@@ -65,7 +65,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         sts.mixin.spec.withServiceName($.thanos.store.service.metadata.name) +
         sts.mixin.spec.selector.withMatchLabels($.thanos.store.statefulSet.metadata.labels) +
         sts.mixin.spec.template.spec.withVolumes([
-          volume.fromEmptyDir('data'),
+          volume.fromEmptyDir($.thanos.store.statefulSet.metadata.name + '-data'),
         ]) +
         {
           spec+: {

--- a/manifests/thanos-store-statefulSet.yaml
+++ b/manifests/thanos-store-statefulSet.yaml
@@ -45,8 +45,8 @@ spec:
             memory: 1Gi
         volumeMounts:
         - mountPath: /var/thanos/store
-          name: data
+          name: thanos-store-data
           readOnly: false
       volumes:
       - emptyDir: {}
-        name: data
+        name: thanos-store-data


### PR DESCRIPTION
It's probably nicer to rename the PVC name to `statefulSet.metadata.name + "-data"`. So we end up with `thanos-store-data` instead of `data`.

/cc @brancz @aditya-konarde @kakkoyun @squat 